### PR TITLE
[C++ gRPC] Fix clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set (CMAKE_MODULE_PATH
 
 # We need to include third-party CMake modules before we configure our own
 # settings so that we don't apply our settings to third-party code.
-include (ThirdParty)
+add_subdirectory (thirdparty)
 
 enable_testing()
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -1,7 +1,0 @@
-set (BOND_ENABLE_GRPC
-    "FALSE"
-    CACHE BOOL "If TRUE, then Bond C++ gRPC support will be built, using the grpc submodule. The grpc pre-requesites will need to have been installed.")
-
-if (BOND_ENABLE_GRPC)
-    add_subdirectory(thirdparty/grpc)
-endif()

--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_cpp.hs
@@ -23,8 +23,10 @@ grpc_cpp cpp file _imports declarations = ("_grpc.cpp", [lt|
 #include "#{file}_reflection.h"
 #include "#{file}_grpc.h"
 
+#ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 4100)
+#endif
 
 //#include <grpc++/impl/codegen/async_stream.h>
 #include <grpc++/impl/codegen/async_unary_call.h>
@@ -40,7 +42,9 @@ grpc_cpp cpp file _imports declarations = ("_grpc.cpp", [lt|
 #{doubleLineSep 1 grpc declarations}
 #{CPP.closeNamespace cpp}
 
+#ifdef _MSC_VER
 #pragma warning (pop)
+#endif
 |])
   where
     idl = MappingContext idlTypeMapping [] [] []

--- a/compiler/tests/generated/generic_service_grpc.cpp
+++ b/compiler/tests/generated/generic_service_grpc.cpp
@@ -2,8 +2,10 @@
 #include "generic_service_reflection.h"
 #include "generic_service_grpc.h"
 
+#ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 4100)
+#endif
 
 //#include <grpc++/impl/codegen/async_stream.h>
 #include <grpc++/impl/codegen/async_unary_call.h>
@@ -67,4 +69,6 @@ Foo::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
 
 } // namespace tests
 
+#ifdef _MSC_VER
 #pragma warning (pop)
+#endif

--- a/compiler/tests/generated/service_attributes_grpc.cpp
+++ b/compiler/tests/generated/service_attributes_grpc.cpp
@@ -2,8 +2,10 @@
 #include "service_attributes_reflection.h"
 #include "service_attributes_grpc.h"
 
+#ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 4100)
+#endif
 
 //#include <grpc++/impl/codegen/async_stream.h>
 #include <grpc++/impl/codegen/async_unary_call.h>
@@ -45,4 +47,6 @@ Foo::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
 
 } // namespace tests
 
+#ifdef _MSC_VER
 #pragma warning (pop)
+#endif

--- a/compiler/tests/generated/service_grpc.cpp
+++ b/compiler/tests/generated/service_grpc.cpp
@@ -2,8 +2,10 @@
 #include "service_reflection.h"
 #include "service_grpc.h"
 
+#ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 4100)
+#endif
 
 //#include <grpc++/impl/codegen/async_stream.h>
 #include <grpc++/impl/codegen/async_unary_call.h>
@@ -212,4 +214,6 @@ Foo::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
 
 } // namespace tests
 
+#ifdef _MSC_VER
 #pragma warning (pop)
+#endif

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,0 +1,6 @@
+include (Compiler)
+
+if (BOND_ENABLE_GRPC)
+    cxx_add_compile_options (Clang -Wno-unused-value)
+    add_subdirectory(grpc)
+endif()


### PR DESCRIPTION
- shuffle cmakelists to ignore unused var warning in borringssl
- fix codegen to avoid clang error