### PR TITLE
[C++ gRPC] Add static library and dll examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,17 @@ cache:
         - cs/packages
         - /home/travis/.ccache
 env:
-    - BOND_LANG="cs"
-    - BOND_LANG="cpp" BOOST="1.63.0"
-    - BOND_LANG="cpp" BOOST="1.62.0"
-    - BOND_LANG="cpp" BOOST="1.61.0"
-    - BOND_LANG="cpp" BOOST="1.60.0"
-    - BOND_LANG="cpp" BOOST="1.59.0"
-    - BOND_LANG="cpp" BOOST="1.58.0"
-    - BOND_LANG="cpp" BOOST="1.63.0" COMM="true"
-    - BOND_LANG="cpp" BOOST="1.63.0" GRPC="true"
-    - BOND_LANG="hs" GHC_VERSION="7.8.4"
-    - BOND_LANG="hs" GHC_VERSION="7.6.3"
+    - FLAVOR="cs"
+    - FLAVOR="cpp-core" BOOST="1.63.0"
+    - FLAVOR="cpp-core" BOOST="1.62.0"
+    - FLAVOR="cpp-core" BOOST="1.61.0"
+    - FLAVOR="cpp-core" BOOST="1.60.0"
+    - FLAVOR="cpp-core" BOOST="1.59.0"
+    - FLAVOR="cpp-core " BOOST="1.58.0"
+    - FLAVOR="cpp-comm" BOOST="1.63.0"
+    - FLAVOR="cpp-grpc" BOOST="1.63.0"
+    - FLAVOR="hs" GHC_VERSION="7.8.4"
+    - FLAVOR="hs" GHC_VERSION="7.6.3"
 addons:
   apt:
     sources:
@@ -45,8 +45,6 @@ before_install:
     - if [ "$CXX" == "" ]; then echo "Setting default $CXX"; export CXX="clang++"; fi
     - if [ "$CC" == "" ]; then echo "Setting default $CC"; export CC="clang"; fi
     - if [ "$BOOST" == "" ]; then echo "Setting default $BOOST"; export BOOST=1.63.0; fi
-    - if [ "$COMM" == "" ]; then echo "Skipping Comm"; export BUILD_COMM="false"; else echo "Building Comm"; export BUILD_COMM="true"; fi
-    - if [ "$GRPC" == "" ]; then echo "Skipping gRPC"; export BUILD_GRPC="false"; else echo "Building gRPC"; export BUILD_GRPC="true"; fi
     # pull down our boost binaries
     - export BOOST_ARCHIVE=boost-$BOOST.tar.xz
     - wget https://bondboostbinaries.blob.core.windows.net/bondboostbinaries/$BOOST_ARCHIVE -O /tmp/$BOOST_ARCHIVE
@@ -61,26 +59,32 @@ before_install:
     - echo "CXX=$CXX"
     - echo "CC=$CC"
     # nunit installation
-    - if [ "$BOND_LANG" == "cs" ]; then travis_retry nuget install NUnit.Runners -version 2.6.4; fi
+    - if [ "$FLAVOR" == "cs" ]; then travis_retry nuget install NUnit.Runners -version 2.6.4; fi
     - export PATH=/opt/cabal/1.22/bin:/opt/ghc/${GHC_VERSION}/bin:$PATH
     - cabal update
     - cabal install happy Cabal
 
 before_script:
     # restore nuget packages for solution
-    - if [ "$BOND_LANG" == "cs" ]; then travis_retry nuget restore cs/cs.sln; fi
+    - if [ "$FLAVOR" == "cs" ]; then travis_retry nuget restore cs/cs.sln; fi
 
 script:
     - mkdir build && cd build
 
-    - cmake -DBOND_ENABLE_COMM:bool=$BUILD_COMM -DBOND_ENABLE_GRPC:bool=$BUILD_GRPC ..
-    - if [ "$BOND_LANG" == "cs" ]; then make --jobs 2 DESTDIR=$HOME install; fi
-    - if [ "$BOND_LANG" == "cs" ]; then cd ..; fi
-    - if [ "$BOND_LANG" == "cs" ]; then export BOND_COMPILER_PATH=$HOME/usr/local/bin; fi
-    - if [ "$BOND_LANG" == "cs" ]; then xbuild /p:Configuration=Debug cs/cs.sln; fi
-    - if [ "$BOND_LANG" == "cs" ]; then xbuild /p:Configuration=Fields cs/cs.sln; fi
-    - if [ "$BOND_LANG" == "cs" ]; then mono NUnit.Runners.2.6.4/tools/nunit-console.exe -framework=mono-4.5 -labels cs/test/core/bin/debug/net45/Properties/Bond.UnitTest.dll cs/test/core/bin/debug/net45/Fields/Bond.UnitTest.dll cs/test/internal/bin/debug/net45/Bond.InternalTest.dll; fi
-    - if [ "$BOND_LANG" == "cpp" ]; then make --jobs 2 check; fi
-    - if [ "$BOND_LANG" == "hs" ]; then make gbc-tests; fi
-    - if [ "$BOND_LANG" == "hs" ]; then cd ../compiler; fi
-    - if [ "$BOND_LANG" == "hs" ]; then ../build/compiler/build/gbc-tests/gbc-tests; fi
+    - if [ "$FLAVOR" == "cs" ]; then cmake ..; fi
+    - if [ "$FLAVOR" == "cs" ]; then make --jobs 2 DESTDIR=$HOME install; fi
+    - if [ "$FLAVOR" == "cs" ]; then cd ..; fi
+    - if [ "$FLAVOR" == "cs" ]; then export BOND_COMPILER_PATH=$HOME/usr/local/bin; fi
+    - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Debug cs/cs.sln; fi
+    - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Fields cs/cs.sln; fi
+    - if [ "$FLAVOR" == "cs" ]; then mono NUnit.Runners.2.6.4/tools/nunit-console.exe -framework=mono-4.5 -labels cs/test/core/bin/debug/net45/Properties/Bond.UnitTest.dll cs/test/core/bin/debug/net45/Fields/Bond.UnitTest.dll cs/test/internal/bin/debug/net45/Bond.InternalTest.dll; fi
+    - if [ "$FLAVOR" == "cpp-core" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_COME=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-core" ]; then make --jobs 2 check; fi
+    - if [ "$FLAVOR" == "cpp-comm" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-comm" ]; then make --jobs 2 check; fi
+    - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-grpc" ]; then make --jobs 2 check; fi
+    - if [ "$FLAVOR" == "hs" ]; then cmake ..; fi
+    - if [ "$FLAVOR" == "hs" ]; then make gbc-tests; fi
+    - if [ "$FLAVOR" == "hs" ]; then cd ../compiler; fi
+    - if [ "$FLAVOR" == "hs" ]; then ../build/compiler/build/gbc-tests/gbc-tests; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
     - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Debug cs/cs.sln; fi
     - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Fields cs/cs.sln; fi
     - if [ "$FLAVOR" == "cs" ]; then mono NUnit.Runners.2.6.4/tools/nunit-console.exe -framework=mono-4.5 -labels cs/test/core/bin/debug/net45/Properties/Bond.UnitTest.dll cs/test/core/bin/debug/net45/Fields/Bond.UnitTest.dll cs/test/internal/bin/debug/net45/Bond.InternalTest.dll; fi
-    - if [ "$FLAVOR" == "cpp-core" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_COME=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-core" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cpp-core" ]; then make --jobs 2 check; fi
     - if [ "$FLAVOR" == "cpp-comm" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cpp-comm" ]; then make --jobs 2 check; fi

--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
@@ -12,7 +12,7 @@ import Prelude
 import qualified Data.Text.Lazy as L
 import Data.Text.Lazy.Builder
 import Text.Shakespeare.Text
--- import Language.Bond.Util
+import Language.Bond.Util
 import Language.Bond.Syntax.Types
 -- import Language.Bond.Syntax.Util
 import Language.Bond.Codegen.Util
@@ -23,7 +23,7 @@ import qualified Language.Bond.Codegen.Cpp.Util as CPP
 -- | Codegen template for generating /base_name/_grpc.h containing declarations of
 -- of service interface and proxy.
 grpc_h :: Maybe String -> MappingContext -> String -> [Import] -> [Declaration] -> (String, L.Text)
-grpc_h _ cpp file imports declarations = ("_grpc.h", [lt|
+grpc_h export_attribute cpp file imports declarations = ("_grpc.h", [lt|
 #pragma once
 
 #include "#{file}_reflection.h"
@@ -111,7 +111,7 @@ public:
         #{doubleLineSep 2 privateStubMethodDecl serviceMethods}
     };
 
-    static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
+    #{export_attr}static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
     class Service : public ::bond::ext::gRPC::detail::service
     {
@@ -131,6 +131,9 @@ public:
     };
 };|]
       where
+        export_attr = optional (\a -> [lt|#{a}
+        |]) export_attribute
+
         methodNames :: [String]
         methodNames = map methodName serviceMethods
 

--- a/examples/cpp/grpc/CMakeLists.txt
+++ b/examples/cpp/grpc/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory (grpc_static_library)
 add_subdirectory (helloworld)

--- a/examples/cpp/grpc/CMakeLists.txt
+++ b/examples/cpp/grpc/CMakeLists.txt
@@ -1,2 +1,5 @@
+if (MSVC)
+    add_subdirectory (grpc_dll)
+endif()
 add_subdirectory (grpc_static_library)
 add_subdirectory (helloworld)

--- a/examples/cpp/grpc/grpc_dll/CMakeLists.txt
+++ b/examples/cpp/grpc/grpc_dll/CMakeLists.txt
@@ -1,0 +1,47 @@
+add_bond_codegen (grpc_dll.bond
+    OPTIONS --header=\\\"dllexample_dynlink.h\\\" --apply=compact --export-attribute=DLLEXAMPLE_DYNLINK
+    GRPC)
+
+add_library (grpc_dll_example_lib EXCLUDE_FROM_ALL
+    SHARED
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_dll_types.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_dll_apply.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_dll_grpc.cpp)
+
+target_include_directories(grpc_dll_example_lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_definitions (grpc_dll_example_lib PRIVATE -DBUILDING_DLLEXAMPLE_DLL)
+
+add_target_to_folder (grpc_dll_example_lib)
+
+target_link_libraries (grpc_dll_example_lib PUBLIC
+    grpc++
+    bond)
+
+# TODO: It feels like the grpc++ target should have this as part of its
+# interface... Perhaps a patch for upstream?
+target_include_directories(grpc_dll_example_lib
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
+)
+
+cxx_target_compile_definitions (MSVC grpc_dll_example_lib PRIVATE
+    -D_WIN32_WINNT=0x0600)
+
+add_bond_test (grpc_dll_example
+    using_grpc_dll.cpp)
+
+target_compile_definitions (grpc_dll_example PRIVATE -DUSING_DLLEXAMPLE_DLL)
+
+target_include_directories(grpc_dll_example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries (grpc_dll_example PUBLIC
+    grpc_dll_example_lib)
+
+# TODO: It feels like the grpc++ target should have this as part of its
+# interface... Perhaps a patch for upstream?
+target_include_directories(grpc_dll_example
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
+)
+
+cxx_target_compile_definitions (MSVC grpc_dll_example PRIVATE
+    -D_WIN32_WINNT=0x0600)

--- a/examples/cpp/grpc/grpc_dll/dllexample_dynlink.h
+++ b/examples/cpp/grpc/grpc_dll/dllexample_dynlink.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(BUILDING_DLLEXAMPLE_DLL)
+    #define DLLEXAMPLE_DYNLINK __declspec(dllexport)
+#elif defined(USING_DLLEXAMPLE_DLL)
+    #define DLLEXAMPLE_DYNLINK __declspec(dllimport)
+#else
+    #define DLLEXAMPLE_DYNLINK
+#endif

--- a/examples/cpp/grpc/grpc_dll/grpc_dll.bond
+++ b/examples/cpp/grpc/grpc_dll/grpc_dll.bond
@@ -1,0 +1,18 @@
+namespace examples.grpc_dll
+
+struct Item
+{
+    0: string       str = "default string value";
+    1: list<uint32> numbers;
+}
+
+struct MyStruct
+{
+    0: vector<Item> items;
+    1: bonded<Item> item;
+}
+
+service TestService
+{
+    Item TestMethod(MyStruct);
+}

--- a/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
+++ b/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
@@ -134,7 +134,7 @@ int main()
 
     std::cout << schema.GetSchema().structs[schema.GetSchema().root.struct_def].fields[0].metadata.name << std::endl;
 
-    // Exercize gRPC facilities
+    // Exercise gRPC facilities
 
     const std::string server_address("127.0.0.1:50051");
 

--- a/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
+++ b/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
@@ -1,0 +1,152 @@
+// The program uses a generated Bond service TestService; however the project
+// doesn't contain any .bond file. Instead it includes headers from
+// and links to grpc_dll_example.dll which contain definition of TestService and
+// pre-built Bond de/serialization code for it. This approach is useful when
+// multiple projects use the same Bond types; it allows compiling Bond code
+// once and distributing as a binary .lib file. The static library needs to be
+// rebuilt only when .bond file (i.e. data schema) changes.  Note that the
+// DLL and the programs that consume it have to use the same version
+// of Bond.
+// This program tests the use of the server-side service implementation.
+#include <grpc_dll_apply.h>
+
+// Reflection header needed only for explicit metadata access -- don't
+// include by default as it will increase your build times
+#include <grpc_dll_reflection.h>
+
+#include <grpc_dll_grpc.h>
+
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 4100)
+#endif
+
+#include <grpc++/grpc++.h>
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif
+
+#include <bond/ext/grpc/server.h>
+#include <bond/ext/grpc/server_builder.h>
+#include <bond/ext/grpc/unary_call.h>
+
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+
+#include <iostream>
+
+using namespace examples::grpc_dll;
+
+
+class TestServiceClient
+{
+public:
+    TestServiceClient(std::shared_ptr<Channel> channel)
+        : stub_(TestService::NewStub(channel))
+    { }
+
+    // Assembles the client's payload, sends it and presents the response back
+    // from the server.
+
+    Item TestMethod(MyStruct &theStruct)
+    {
+        ClientContext context;
+
+        // The actual RPC.
+        bond::comm::message<MyStruct> req(theStruct);
+        bond::comm::message<Item> rep;
+        Status status = stub_->TestMethod(&context, req, &rep);
+
+        if (!status.ok()) {
+           std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+        }
+
+        return rep.value().Deserialize();
+    }
+
+private:
+    std::unique_ptr<TestService::Stub> stub_;
+
+};
+
+struct TestServiceImpl : TestService::Service
+{
+    void TestMethod(::bond::ext::gRPC::unary_call<
+                        ::bond::comm::message< ::examples::grpc_dll::MyStruct>,
+                        ::bond::comm::message< ::examples::grpc_dll::Item>> call) override
+    {
+        MyStruct request = call.request().value().Deserialize();
+        Item response;
+        response = request.items[0];
+         
+        bond::comm::message<Item> resp(response);
+        call.Finish(resp, Status::OK);
+    }
+};
+
+int main()
+{
+    // Exercise Core facilities
+
+    MyStruct obj;
+
+    // Initialize
+    obj.items.resize(1);
+    obj.items[0].numbers.push_back(13);
+
+    Item item;
+
+    item.numbers.push_back(11);
+    obj.item = bond::bonded<Item>(item);
+
+    // Serialize
+    bond::OutputBuffer buffer;
+    bond::CompactBinaryWriter<bond::OutputBuffer> writer(buffer);
+    bond::Serialize(obj, writer);
+        
+    bond::blob data = buffer.GetBuffer();
+
+    MyStruct obj2;
+
+    // Deserialize
+    bond::CompactBinaryReader<bond::InputBuffer> reader(data);
+    bond::Deserialize(reader, obj2);
+
+    Item item2;
+    
+    obj2.item.Deserialize(item2);
+
+    // Access metadata
+    bond::Metadata myMetadata = MyStruct::Schema::GetMetadata();
+
+    std::cout << myMetadata.name << std::endl;
+
+    bond::RuntimeSchema schema = bond::GetRuntimeSchema<MyStruct>();
+
+    std::cout << schema.GetSchema().structs[schema.GetSchema().root.struct_def].fields[0].metadata.name << std::endl;
+
+    // Exersize gRPC facilities
+
+    const std::string server_address("127.0.0.1:50051");
+
+    // Create a service instance
+    TestServiceImpl service;
+    bond::ext::gRPC::server_builder builder;
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service);
+    std::unique_ptr<bond::ext::gRPC::server> server(builder.BuildAndStart());
+
+    // Create a proxy
+    TestServiceClient stub(grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials()));
+
+    return 0;
+}

--- a/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
+++ b/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
@@ -134,7 +134,7 @@ int main()
 
     std::cout << schema.GetSchema().structs[schema.GetSchema().root.struct_def].fields[0].metadata.name << std::endl;
 
-    // Exersize gRPC facilities
+    // Exercize gRPC facilities
 
     const std::string server_address("127.0.0.1:50051");
 

--- a/examples/cpp/grpc/grpc_static_library/CMakeLists.txt
+++ b/examples/cpp/grpc/grpc_static_library/CMakeLists.txt
@@ -1,0 +1,48 @@
+add_bond_codegen (lib/grpc_static_library.bond
+    OPTIONS --apply=compact
+    GRPC)
+
+add_library (grpc_static_library_lib EXCLUDE_FROM_ALL
+    STATIC
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_static_library_types.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_static_library_apply.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/grpc_static_library_grpc.cpp)
+
+add_target_to_folder (grpc_static_library_lib)
+
+target_link_libraries (grpc_static_library_lib PUBLIC
+    grpc++
+    bond)
+
+add_bond_test (grpc_static_library_server
+    server/grpc_static_library_server.cpp)
+
+target_link_libraries (grpc_static_library_server PRIVATE
+    grpc_static_library_lib)
+
+add_bond_test (grpc_static_library_client
+    client/grpc_static_library_client.cpp)
+
+target_link_libraries (grpc_static_library_client PRIVATE
+    grpc_static_library_lib)
+
+# TODO: It feels like the grpc++ target should have this as part of its
+# interface... Perhaps a patch for upstream?
+target_include_directories(grpc_static_library_lib
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
+)
+target_include_directories(grpc_static_library_server
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
+)
+target_include_directories(grpc_static_library_client
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
+)
+
+cxx_target_compile_definitions (MSVC grpc_static_library_lib PRIVATE
+    -D_WIN32_WINNT=0x0600)
+
+cxx_target_compile_definitions (MSVC grpc_static_library_server PRIVATE
+    -D_WIN32_WINNT=0x0600)
+
+cxx_target_compile_definitions (MSVC grpc_static_library_client PRIVATE
+    -D_WIN32_WINNT=0x0600)

--- a/examples/cpp/grpc/grpc_static_library/client/grpc_static_library_client.cpp
+++ b/examples/cpp/grpc/grpc_static_library/client/grpc_static_library_client.cpp
@@ -1,0 +1,100 @@
+// The program uses a generated Bond service PingPong; however the project
+// doesn't contain any .bond file. Instead it includes
+// grpc_static_library_apply.h and grpc_static_library_comm.h
+// and links to grpc_static_library.lib which contain definition of PingPong and
+// pre-built Bond de/serialization code for it. This approach is useful when
+// multiple projects use the same Bond types; it allows compiling Bond code
+// once and distributing as a binary .lib file. The static library needs to be
+// rebuilt only when .bond file (i.e. data schema) changes.  Note that the
+// static library and the programs that consume it have to use the same version
+// of Bond.
+// This program tests the use of the client-side proxies.
+#include <grpc_static_library_apply.h>
+#include <grpc_static_library_reflection.h>
+#include <grpc_static_library_grpc.h>
+
+// We still need to include Bond headers, however only small inline functions
+// will be compiled as part of this file and expensive to build de/serialization
+// code will be linked in from static_library.lib.
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 4100)
+#endif
+
+#include <grpc++/grpc++.h>
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+using namespace examples::grpc_static_library;
+
+class PingPongClient
+{
+public:
+    PingPongClient(std::shared_ptr<Channel> channel)
+        : stub_(PingPong::NewStub(channel))
+    { }
+
+    // Assembles the client's payload, sends it and presents the response back
+    // from the server.
+    std::string Ping(const std::string& message)
+    {
+        ClientContext context;
+
+        PingRequest request;
+        request.Payload = message;
+
+        PingResponse reply;
+
+        // The actual RPC.
+        bond::comm::message<PingRequest> req(request);
+        bond::comm::message<PingResponse> rep;
+        Status status = stub_->Ping(&context, req, &rep);
+
+        if (status.ok()) {
+            return rep.value().Deserialize().Payload;
+        }
+        else {
+            std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+            return "RPC failed";
+        }
+    }
+
+private:
+    std::unique_ptr<PingPong::Stub> stub_;
+
+};
+
+int main()
+{
+    PingRequest obj;
+
+    obj.Payload = "ping0";
+
+    bond::OutputBuffer buffer;
+    bond::CompactBinaryWriter<bond::OutputBuffer> writer(buffer);
+    bond::Serialize(obj, writer);
+
+    bond::blob data = buffer.GetBuffer();
+
+    PingRequest obj2;
+
+    // Deserialize
+    bond::CompactBinaryReader<bond::InputBuffer> reader(data);
+    bond::Deserialize(reader, obj2);
+
+    // Access metadata
+    bond::Metadata myMetadata = PingRequest::Schema::GetMetadata();
+
+    // Initialize proxy
+    const std::string server_address("127.0.0.1:50051");
+    PingPongClient client(grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials()));
+
+    return 0;
+}

--- a/examples/cpp/grpc/grpc_static_library/lib/grpc_static_library.bond
+++ b/examples/cpp/grpc/grpc_static_library/lib/grpc_static_library.bond
@@ -1,0 +1,16 @@
+namespace examples.grpc_static_library
+
+struct PingRequest
+{
+    0: string Payload;
+}
+
+struct PingResponse
+{
+    0: string Payload;
+}
+
+service PingPong
+{
+    PingResponse Ping(PingRequest);
+}

--- a/examples/cpp/grpc/grpc_static_library/lib/pingpong_service.h
+++ b/examples/cpp/grpc/grpc_static_library/lib/pingpong_service.h
@@ -1,0 +1,55 @@
+#include <bond/ext/grpc/detail/service.h>
+#include <bond/ext/grpc/detail/service_call_data.h>
+#include <bond/ext/grpc/server.h>
+#include <bond/ext/grpc/server_builder.h>
+#include <bond/ext/grpc/unary_call.h>
+
+#include <bond/ext/grpc/bond_utils.h>
+
+
+// TODO: generate this code instead of writing it by hand
+class PingPongServiceAsync : public bond::ext::gRPC::detail::service
+{
+public:
+    PingPongServiceAsync()
+    {
+        // code gen a call to AddMethod for each method with the right name. Order will matter.
+        AddMethod("/examples/grpc_static_library.PingPong/Ping");
+    }
+
+    // code gen a virtual method with a signature like this
+    virtual void Ping(
+        bond::ext::gRPC::unary_call<
+            bond::comm::message<::examples::grpc_static_library::PingRequest>,
+            bond::comm::message<::examples::grpc_static_library::PingResponse>> call) = 0;
+
+    void start(grpc::ServerCompletionQueue* cq) override
+    {
+        BOOST_ASSERT(cq);
+
+        // for each method, actually initialize the service_unary_call_data
+        _receivePingPong.emplace(
+            this,
+            0,
+            cq,
+            std::bind(
+                &PingPongServiceAsync::Ping,
+                this,
+                std::placeholders::_1));
+
+        // code gen enqueueing a receive to start processing the method
+        queue_receive(
+            0,
+            &_receivePingPong->_receivedCall->_context,
+            &_receivePingPong->_receivedCall->_request,
+            &_receivePingPong->_receivedCall->_responder,
+            cq,
+            &_receivePingPong.get());
+    }
+
+private:
+    // code gen a data member for each method
+    boost::optional<bond::ext::gRPC::detail::service_unary_call_data<
+        bond::comm::message<::examples::grpc_static_library::PingRequest>,
+        bond::comm::message<::examples::grpc_static_library::PingResponse>>> _receivePingPong;
+};

--- a/examples/cpp/grpc/grpc_static_library/server/grpc_static_library_server.cpp
+++ b/examples/cpp/grpc/grpc_static_library/server/grpc_static_library_server.cpp
@@ -1,0 +1,85 @@
+// The program uses a generated Bond service PingPong; however the project
+// doesn't contain any .bond file. Instead it includes
+// grpc_static_library_apply.h and grpc_static_library_comm.h
+// and links to grpc_static_library.lib which contain definition of PingPong and
+// pre-built Bond de/serialization code for it. This approach is useful when
+// multiple projects use the same Bond types; it allows compiling Bond code
+// once and distributing as a binary .lib file. The static library needs to be
+// rebuilt only when .bond file (i.e. data schema) changes.  Note that the
+// static library and the programs that consume it have to use the same version
+// of Bond.
+// This program tests the use of the server-side service implementation.
+#include <grpc_static_library_apply.h>
+#include <grpc_static_library_reflection.h>
+#include <grpc_static_library_grpc.h>
+
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 4100)
+#endif
+
+#include <grpc++/grpc++.h>
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif
+
+#include <bond/ext/grpc/server.h>
+#include <bond/ext/grpc/server_builder.h>
+#include <bond/ext/grpc/unary_call.h>
+
+using grpc::Status;
+using grpc::StatusCode;
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+
+using namespace examples::grpc_static_library;
+
+class PingPongServiceImpl final : public PingPong::Service {
+
+    void Ping(
+        bond::ext::gRPC::unary_call<
+        bond::comm::message<::examples::grpc_static_library::PingRequest>,
+        bond::comm::message<::examples::grpc_static_library::PingResponse>> call) override
+    {
+        PingRequest request = call.request().value().Deserialize();
+        PingResponse response;
+        response.Payload = request.Payload;
+
+        bond::comm::message<PingResponse> resp(response);
+        call.Finish(resp, Status::OK);
+     }
+};
+
+int main()
+{
+    PingRequest obj;
+
+    obj.Payload = "ping0";
+
+    bond::OutputBuffer buffer;
+    bond::CompactBinaryWriter<bond::OutputBuffer> writer(buffer);
+    bond::Serialize(obj, writer);
+
+    bond::blob data = buffer.GetBuffer();
+
+    PingRequest obj2;
+
+    // Deserialize
+    bond::CompactBinaryReader<bond::InputBuffer> reader(data);
+    bond::Deserialize(reader, obj2);
+
+    // Access metadata
+    bond::Metadata myMetadata = PingRequest::Schema::GetMetadata();
+
+    const std::string server_address("127.0.0.1:50051");
+    PingPongServiceImpl service;
+    bond::ext::gRPC::server_builder builder;
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service);
+    std::unique_ptr<bond::ext::gRPC::server> server(builder.BuildAndStart());
+
+    return 0;
+}


### PR DESCRIPTION
Add examples demonstrating use of static libraries and dll examples for Bond-over-gRPC. Includes gbc changes to emit dll declspec attributes on <service>::NewStub() call.