### PR TITLE
[c++ grpc] Switch from comm's message to bonded

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_cpp.hs
@@ -34,7 +34,7 @@ grpc_cpp cpp file _imports declarations = ("_grpc.cpp", [lt|
     request mt = request' (payload mt)
       where
         payload = maybe "void" cppType
-        request' params =  [lt|::bond::comm::message<#{padLeft}#{params}>|]
+        request' params =  [lt|::bond::bonded<#{padLeft}#{params}>|]
           where
             paramsText = toLazyText params
             padLeft = if L.head paramsText == ':' then [lt| |] else mempty
@@ -42,7 +42,7 @@ grpc_cpp cpp file _imports declarations = ("_grpc.cpp", [lt|
     response mt = response' (payload mt)
       where
         payload = maybe "void" cppType
-        response' params =  [lt|::bond::comm::message<#{padLeft}#{params}>|]
+        response' params =  [lt|::bond::bonded<#{padLeft}#{params}>|]
           where
             paramsText = toLazyText params
             padLeft = if L.head paramsText == ':' then [lt| |] else mempty

--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
@@ -28,8 +28,7 @@ grpc_h _ cpp file imports declarations = ("_grpc.h", [lt|
 #include "#{file}_reflection.h"
 #include "#{file}_types.h"
 #{newlineSep 0 includeImport imports}
-// todo: remove message
-#include <bond/comm/message.h>
+#include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -72,7 +71,7 @@ grpc_h _ cpp file imports declarations = ("_grpc.h", [lt|
     request mt = request' (payload mt)
       where
         payload = maybe "void" cppType
-        request' params =  [lt|::bond::comm::message<#{padLeft}#{params}>|]
+        request' params =  [lt|::bond::bonded<#{padLeft}#{params}>|]
           where
             paramsText = toLazyText params
             padLeft = if L.head paramsText == ':' then [lt| |] else mempty
@@ -80,7 +79,7 @@ grpc_h _ cpp file imports declarations = ("_grpc.h", [lt|
     response mt = response' (payload mt)
       where
         payload = maybe "void" cppType
-        response' params =  [lt|::bond::comm::message<#{padLeft}#{params}>|]
+        response' params =  [lt|::bond::bonded<#{padLeft}#{params}>|]
           where
             paramsText = toLazyText params
             padLeft = if L.head paramsText == ':' then [lt| |] else mempty

--- a/compiler/tests/generated/generic_service_grpc.cpp
+++ b/compiler/tests/generated/generic_service_grpc.cpp
@@ -19,21 +19,21 @@ Foo::FooClient::FooClient(const std::shared_ptr< ::grpc::ChannelInterface>& chan
     , rpcmethod_foo33_(Foo_method_names[2], ::grpc::RpcMethod::NORMAL_RPC, channel)
     { }
 
-void Foo::FooClient::Asyncfoo31(::grpc::ClientContext* context, const ::bond::comm::message<Payload>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo31(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<Payload>, ::bond::comm::message<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<Payload>, ::bond::comm::message<void> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<void> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo31_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo32(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<Payload>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo32(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<Payload> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<Payload> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<Payload> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<Payload> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo32_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo33(::grpc::ClientContext* context, const ::bond::comm::message<Payload>& request, std::function<void(const ::bond::comm::message<Payload>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<Payload>, ::bond::comm::message<Payload> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<Payload>, ::bond::comm::message<Payload> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<Payload> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<Payload> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo33_, context, request);
 }
 

--- a/compiler/tests/generated/generic_service_grpc.h
+++ b/compiler/tests/generated/generic_service_grpc.h
@@ -4,8 +4,7 @@
 #include "generic_service_reflection.h"
 #include "generic_service_types.h"
 
-// todo: remove message
-#include <bond/comm/message.h>
+#include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -43,11 +42,11 @@ public:
     public:
         FooClient(const std::shared_ptr< ::grpc::ChannelInterface>& channel, std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager);
 
-        void Asyncfoo31(::grpc::ClientContext* context, const ::bond::comm::message<Payload>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb);
+        void Asyncfoo31(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo32(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<Payload>&, const ::grpc::Status&)> cb);
+        void Asyncfoo32(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::comm::message<Payload>& request, std::function<void(const ::bond::comm::message<Payload>&, const ::grpc::Status&)> cb);
+        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)> cb);
 
         FooClient(const FooClient&) = delete;
         FooClient& operator=(const FooClient&) = delete;
@@ -90,14 +89,14 @@ public:
             queue_receive(2, &_rd_foo33->_receivedCall->_context, &_rd_foo33->_receivedCall->_request, &_rd_foo33->_receivedCall->_responder, cq, &_rd_foo33.get());
         }
 
-        virtual void foo31(::bond::ext::gRPC::unary_call<::bond::comm::message<Payload>, ::bond::comm::message<void>>) = 0;
-        virtual void foo32(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message<Payload>>) = 0;
-        virtual void foo33(::bond::ext::gRPC::unary_call<::bond::comm::message<Payload>, ::bond::comm::message<Payload>>) = 0;
+        virtual void foo31(::bond::ext::gRPC::unary_call<::bond::bonded<Payload>, ::bond::bonded<void>>) = 0;
+        virtual void foo32(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded<Payload>>) = 0;
+        virtual void foo33(::bond::ext::gRPC::unary_call<::bond::bonded<Payload>, ::bond::bonded<Payload>>) = 0;
 
     private:
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<Payload>, ::bond::comm::message<void>>> _rd_foo31;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message<Payload>>> _rd_foo32;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<Payload>, ::bond::comm::message<Payload>>> _rd_foo33;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<Payload>, ::bond::bonded<void>>> _rd_foo31;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded<Payload>>> _rd_foo32;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<Payload>, ::bond::bonded<Payload>>> _rd_foo33;
     };
 };
 

--- a/compiler/tests/generated/service_attributes_grpc.cpp
+++ b/compiler/tests/generated/service_attributes_grpc.cpp
@@ -15,9 +15,9 @@ Foo::FooClient::FooClient(const std::shared_ptr< ::grpc::ChannelInterface>& chan
     , rpcmethod_foo_(Foo_method_names[0], ::grpc::RpcMethod::NORMAL_RPC, channel)
     { }
 
-void Foo::FooClient::Asyncfoo(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::Param>& request, std::function<void(const ::bond::comm::message< ::tests::Result>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo(::grpc::ClientContext* context, const ::bond::bonded< ::tests::Param>& request, std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::Param>, ::bond::comm::message< ::tests::Result> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::Param>, ::bond::comm::message< ::tests::Result> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo_, context, request);
 }
 

--- a/compiler/tests/generated/service_attributes_grpc.h
+++ b/compiler/tests/generated/service_attributes_grpc.h
@@ -4,8 +4,7 @@
 #include "service_attributes_reflection.h"
 #include "service_attributes_types.h"
 
-// todo: remove message
-#include <bond/comm/message.h>
+#include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -43,7 +42,7 @@ public:
     public:
         FooClient(const std::shared_ptr< ::grpc::ChannelInterface>& channel, std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager);
 
-        void Asyncfoo(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::Param>& request, std::function<void(const ::bond::comm::message< ::tests::Result>&, const ::grpc::Status&)> cb);
+        void Asyncfoo(::grpc::ClientContext* context, const ::bond::bonded< ::tests::Param>& request, std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)> cb);
 
         FooClient(const FooClient&) = delete;
         FooClient& operator=(const FooClient&) = delete;
@@ -76,10 +75,10 @@ public:
             queue_receive(0, &_rd_foo->_receivedCall->_context, &_rd_foo->_receivedCall->_request, &_rd_foo->_receivedCall->_responder, cq, &_rd_foo.get());
         }
 
-        virtual void foo(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::Param>, ::bond::comm::message< ::tests::Result>>) = 0;
+        virtual void foo(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result>>) = 0;
 
     private:
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::Param>, ::bond::comm::message< ::tests::Result>>> _rd_foo;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result>>> _rd_foo;
     };
 };
 

--- a/compiler/tests/generated/service_grpc.cpp
+++ b/compiler/tests/generated/service_grpc.cpp
@@ -65,87 +65,87 @@ Foo::FooClient::FooClient(const std::shared_ptr< ::grpc::ChannelInterface>& chan
 
 /* TODO: stub implementation for event foo15 */
 
-void Foo::FooClient::Asyncfoo21(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo21(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<void> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<void> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo21_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo22(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo22(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message<void> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded<void> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo22_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo23(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo23(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message<void> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded<void> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo23_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo24(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo24(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message<void> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded<void> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded<void> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo24_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo31(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo31(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo31_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo32(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo32(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo32_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo33(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo33_, context, request);
 }
 
-void Foo::FooClient::Async_rd_foo33(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Async_rd_foo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod__rd_foo33_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo34(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo34(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo34_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo41(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo41(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::dummy> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo41_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo42(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo42(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::dummy> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo42_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo43(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo43(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::dummy> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo43_, context, request);
 }
 
-void Foo::FooClient::Asyncfoo44(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asyncfoo44(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::dummy> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_foo44_, context, request);
 }
 
-void Foo::FooClient::Asynccq(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
+void Foo::FooClient::Asynccq(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb)
 {
-    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes> >(cb);
+    ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >* calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes> >(cb);
     calldata->dispatch(channel_.get(), ioManager_.get(), rpcmethod_cq_, context, request);
 }
 

--- a/compiler/tests/generated/service_grpc.h
+++ b/compiler/tests/generated/service_grpc.h
@@ -5,8 +5,7 @@
 #include "service_types.h"
 #include "basic_types_grpc.h"
 #include "namespace_basic_types_grpc.h"
-// todo: remove message
-#include <bond/comm/message.h>
+#include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -56,33 +55,33 @@ public:
 
         /* TODO stub implementation (public) for event foo15 */
 
-        void Asyncfoo21(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb);
+        void Asyncfoo21(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo22(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb);
+        void Asyncfoo22(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo23(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb);
+        void Asyncfoo23(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo24(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message<void>&, const ::grpc::Status&)> cb);
+        void Asyncfoo24(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded<void>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo31(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Asyncfoo31(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo32(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Asyncfoo32(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
-        void Async_rd_foo33(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Async_rd_foo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo34(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Asyncfoo34(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo41(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb);
+        void Asyncfoo41(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo42(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb);
+        void Asyncfoo42(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo43(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::BasicTypes>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb);
+        void Asyncfoo43(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb);
 
-        void Asyncfoo44(::grpc::ClientContext* context, const ::bond::comm::message< ::tests::dummy>& request, std::function<void(const ::bond::comm::message< ::tests::dummy>&, const ::grpc::Status&)> cb);
+        void Asyncfoo44(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)> cb);
 
-        void Asynccq(::grpc::ClientContext* context, const ::bond::comm::message<void>& request, std::function<void(const ::bond::comm::message< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
+        void Asynccq(::grpc::ClientContext* context, const ::bond::bonded<void>& request, std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)> cb);
 
         FooClient(const FooClient&) = delete;
         FooClient& operator=(const FooClient&) = delete;
@@ -216,20 +215,20 @@ public:
         /* TODO: abstract method for event foo13 */
         /* TODO: abstract method for event foo14 */
         /* TODO: abstract method for event foo15 */
-        virtual void foo21(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message<void>>) = 0;
-        virtual void foo22(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message<void>>) = 0;
-        virtual void foo23(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message<void>>) = 0;
-        virtual void foo24(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::dummy>, ::bond::comm::message<void>>) = 0;
-        virtual void foo31(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
-        virtual void foo32(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
-        virtual void foo33(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
-        virtual void _rd_foo33(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
-        virtual void foo34(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
-        virtual void foo41(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy>>) = 0;
-        virtual void foo42(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy>>) = 0;
-        virtual void foo43(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::dummy>>) = 0;
-        virtual void foo44(::bond::ext::gRPC::unary_call<::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::dummy>>) = 0;
-        virtual void cq(::bond::ext::gRPC::unary_call<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>) = 0;
+        virtual void foo21(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded<void>>) = 0;
+        virtual void foo22(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded<void>>) = 0;
+        virtual void foo23(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded<void>>) = 0;
+        virtual void foo24(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::dummy>, ::bond::bonded<void>>) = 0;
+        virtual void foo31(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
+        virtual void foo32(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
+        virtual void foo33(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
+        virtual void _rd_foo33(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
+        virtual void foo34(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
+        virtual void foo41(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded< ::tests::dummy>>) = 0;
+        virtual void foo42(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded< ::tests::dummy>>) = 0;
+        virtual void foo43(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy>>) = 0;
+        virtual void foo44(::bond::ext::gRPC::unary_call<::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy>>) = 0;
+        virtual void cq(::bond::ext::gRPC::unary_call<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>) = 0;
 
     private:
         /* TODO: receive data for event foo11 */
@@ -238,20 +237,20 @@ public:
         /* TODO: receive data for event foo13 */
         /* TODO: receive data for event foo14 */
         /* TODO: receive data for event foo15 */
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message<void>>> _rd_foo21;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message<void>>> _rd_foo22;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message<void>>> _rd_foo23;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::dummy>, ::bond::comm::message<void>>> _rd_foo24;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>> _rd_foo31;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>> _rd_foo32;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes>>> _rd_foo330;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::BasicTypes>>> _rd__rd_foo33;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::BasicTypes>>> _rd_foo34;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy>>> _rd_foo41;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message< ::tests::dummy>>> _rd_foo42;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::BasicTypes>, ::bond::comm::message< ::tests::dummy>>> _rd_foo43;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message< ::tests::dummy>, ::bond::comm::message< ::tests::dummy>>> _rd_foo44;
-        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::comm::message<void>, ::bond::comm::message< ::tests::BasicTypes>>> _rd_cq;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded<void>>> _rd_foo21;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded<void>>> _rd_foo22;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded<void>>> _rd_foo23;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::dummy>, ::bond::bonded<void>>> _rd_foo24;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>> _rd_foo31;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>> _rd_foo32;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>>> _rd_foo330;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>>> _rd__rd_foo33;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes>>> _rd_foo34;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded< ::tests::dummy>>> _rd_foo41;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded< ::tests::dummy>>> _rd_foo42;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy>>> _rd_foo43;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy>>> _rd_foo44;
+        boost::optional<::bond::ext::gRPC::detail::service_unary_call_data<::bond::bonded<void>, ::bond::bonded< ::tests::BasicTypes>>> _rd_cq;
     };
 };
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,8 +53,7 @@ list (APPEND headers
     ${protocol_detail_headers}
     ${stream_headers})
 
-# gRPC integration currently requires portions of Bond Comm
-if ((BOND_ENABLE_COMM) OR (BOND_ENABLE_GRPC))
+if (BOND_ENABLE_COMM)
     set (comm_schemas
         ${BOND_IDL}/bond/comm/comm.bond
         ${BOND_IDL}/bond/comm/transport/packet.bond
@@ -104,7 +103,7 @@ if ((BOND_ENABLE_COMM) OR (BOND_ENABLE_GRPC))
         ${comm_layers_headers}
         ${comm_transport_headers}
         ${comm_transport_detail_headers})
-endif((BOND_ENABLE_COMM) OR (BOND_ENABLE_GRPC))
+endif(BOND_ENABLE_COMM)
 
 source_group ("generated" FILES ${generated_files})
 

--- a/cpp/test/compat/grpc/pingpong_client.cpp
+++ b/cpp/test/compat/grpc/pingpong_client.cpp
@@ -38,10 +38,10 @@ public:
     wait_callback& operator=(const wait_callback&) = delete;
     wait_callback& operator=(wait_callback&&) = delete;
 
-    std::function<void(const ::bond::comm::message<TResponse>&, const ::grpc::Status&)> callback()
+    std::function<void(const bond::bonded<TResponse>&, const ::grpc::Status&)> callback()
     {
-        return std::function<void(const ::bond::comm::message<TResponse>&, const ::grpc::Status&)>(
-            [this](const ::bond::comm::message<TResponse>& response, const ::grpc::Status& status)
+        return std::function<void(const bond::bonded<TResponse>&, const ::grpc::Status&)>(
+            [this](const bond::bonded<TResponse>& response, const ::grpc::Status& status)
             {
                 _response.emplace(response);
                 _status.emplace(status);
@@ -49,7 +49,7 @@ public:
             });
     }
 
-    operator std::function<void(const ::bond::comm::message<TResponse>&, const ::grpc::Status&)>()
+    operator std::function<void(const bond::bonded<TResponse>&, const ::grpc::Status&)>()
     {
         return callback();
     }
@@ -65,7 +65,7 @@ public:
         return _event.wait(timeout);
     }
 
-    const ::bond::comm::message<TResponse>& response() const
+    const bond::bonded<TResponse>& response() const
     {
         return _response.get();
     }
@@ -76,7 +76,7 @@ public:
     }
 
 private:
-    boost::optional<::bond::comm::message<TResponse>> _response;
+    boost::optional<bond::bonded<TResponse>> _response;
     boost::optional<grpc::Status> _status;
 
     bond::ext::detail::event _event;
@@ -112,7 +112,7 @@ int main()
             fflush(stdout);
 
             wait_callback<PingResponse> cb;
-            client.AsyncPing(&context, request, cb);
+            client.AsyncPing(&context, bond::bonded<PingRequest>{ request }, cb);
             bool gotResponse = cb.wait(std::chrono::seconds(1));
 
             if (!gotResponse)
@@ -132,7 +132,7 @@ int main()
                 exit(1);
             }
 
-            if (cb.response().value().Deserialize().Payload != request.Payload)
+            if (cb.response().Deserialize().Payload != request.Payload)
             {
                 printf("Response payload did not match request\n");
                 printf("Client failed\n");
@@ -150,7 +150,7 @@ int main()
             request.Action = PingAction::Error;
 
             wait_callback<PingResponse> cb;
-            client.AsyncPing(&context, request, cb);
+            client.AsyncPing(&context, bond::bonded<PingRequest> { request }, cb);
             bool gotResponse = cb.wait(std::chrono::seconds(1));
 
             if (!gotResponse)
@@ -164,7 +164,7 @@ int main()
 
             if (status.ok())
             {
-                printf("Non-error response received: %s\n", cb.response().value().Deserialize().Payload.c_str());
+                printf("Non-error response received: %s\n", cb.response().Deserialize().Payload.c_str());
                 printf("Client failed\n");
                 fflush(stdout);
                 exit(1);

--- a/cpp/test/compat/grpc/pingpong_server.cpp
+++ b/cpp/test/compat/grpc/pingpong_server.cpp
@@ -38,10 +38,10 @@ public:
 
     void Ping(
         bond::ext::gRPC::unary_call<
-            bond::comm::message<::PingPongNS::PingRequest>,
-            bond::comm::message<::PingPongNS::PingResponse>> call) override
+            bond::bonded<::PingPongNS::PingRequest>,
+            bond::bonded<::PingPongNS::PingResponse>> call) override
     {
-        PingRequest request = call.request().value().Deserialize();
+        PingRequest request = call.request().Deserialize();
 
         switch (request.Action)
         {
@@ -52,11 +52,11 @@ public:
 
                 PingResponse response;
                 response.Payload = request.Payload;
+
                 NumRequestsReceived++;
                 Countdown.set();
 
-                bond::comm::message<PingResponse> resp(response);
-                call.Finish(resp, Status::OK);
+                call.Finish(bond::bonded<PingResponse>{ response }, Status::OK);
                 break;
             }
 

--- a/examples/cpp/grpc/helloworld/helloworld.cpp
+++ b/examples/cpp/grpc/helloworld/helloworld.cpp
@@ -15,8 +15,6 @@
 // event.h needed for test purposes
 #include <bond/ext/detail/event.h>
 
-// todo: remove message
-#include <bond/comm/message.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/server.h>
 #include <bond/ext/grpc/server_builder.h>
@@ -39,31 +37,34 @@ using bond::ext::gRPC::io_manager;
 using namespace helloworld;
 
 // Logic and data behind the server's behavior.
-class GreeterServiceImpl final : public Greeter::Service {
+class GreeterServiceImpl final : public Greeter::Service
+{
     void SayHello(
         bond::ext::gRPC::unary_call<
-            bond::comm::message<HelloRequest>,
-            bond::comm::message<HelloReply>> call) override
+        bond::bonded<HelloRequest>,
+        bond::bonded<HelloReply>> call) override
     {
-        HelloReply real_reply;
-        real_reply.message = "hello " + call.request().value().Deserialize().name;
+        HelloRequest request = call.request().Deserialize();
 
-        bond::comm::message<HelloReply> rep(real_reply);
+        HelloReply reply;
+        reply.message = "hello " + request.name;
 
-        call.Finish(rep, Status::OK);
+        call.Finish(bond::bonded<HelloReply>{reply}, Status::OK);
     }
 };
 
-void printAndSet(event* print_event,
-        bool* isCorrectResponse,
-        const bond::comm::message< HelloReply>& response,
-        const Status& status) {
+void printAndSet(
+    event* print_event,
+    bool* isCorrectResponse,
+    const bond::bonded<HelloReply>& response,
+    const Status& status)
+{
 
     *isCorrectResponse = false;
 
     if(status.ok())
     {
-        std::string message = response.value().Deserialize().message;
+        const std::string& message = response.Deserialize().message;
 
         if (message.compare("hello world") == 0)
         {
@@ -98,15 +99,16 @@ int main()
 
     ClientContext context;
 
-    std::string user("world");
+    const std::string user("world");
+
     HelloRequest request;
     request.name = user;
-    bond::comm::message<HelloRequest> req(request);
+    bond::bonded<HelloRequest> req(request);
     event print_event;
     bool isCorrectResponse;
 
-    std::function<void(const bond::comm::message< HelloReply>&, const Status&)> f_print =
-        [&print_event, &isCorrectResponse](bond::comm::message< HelloReply> response, Status status)
+    std::function<void(const bond::bonded<HelloReply>&, const Status&)> f_print =
+        [&print_event, &isCorrectResponse](bond::bonded<HelloReply> response, Status status)
         {
             printAndSet(&print_event, &isCorrectResponse, response, status);
         };


### PR DESCRIPTION
The use of bond::comm::message was just a placeholder. Its functionality
is not needed, so it has been replaced with just bond::bonded.